### PR TITLE
Update dependencies for 2020

### DIFF
--- a/app.js
+++ b/app.js
@@ -10,26 +10,35 @@ var http = require('http');
 var path = require('path');
 var compass = require('node-compass');
 
+var favicon = require('serve-favicon');
+var logger = require('morgan');
+var methodOverride = require('method-override');
+var session = require('express-session');
+var bodyParser = require('body-parser');
+var errorHandler = require('errorhandler')
+
 var app = express();
 app.engine('html', require('hogan-express'));
 // all environments
 app.set('port', process.env.PORT || 3000);
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'html');
-app.use(express.favicon());
-app.use(express.logger('dev'));
-app.use(express.json());
-app.use(express.urlencoded());
-app.use(express.methodOverride());
-app.use(express.cookieParser('enmlEditorSecret'));
-app.use(express.session());
-app.use(app.router);
+//app.use(favicon(path.join(__dirname, '/public/favicon.ico')));
+app.use(logger('dev'));
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({extended: true}));
+app.use(methodOverride());
+app.use(session({
+  resave: true,
+  saveUninitialized: true,
+  secret: 'enmlEditorSecret'
+}));
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(compass({mode: 'compact', comments: true}));
 
 // development only
 if ('development' == app.get('env')) {
-  app.use(express.errorHandler());
+  app.use(errorHandler());
 }
 
 app.get('/', routes.index);

--- a/package.json
+++ b/package.json
@@ -6,9 +6,15 @@
     "start": "node app.js"
   },
   "dependencies": {
-    "express": "3.4.4",
-    "evernote": "*",
-    "hogan-express": "*",
-    "node-compass": "*"
+    "body-parser": "^1.19.0",
+    "errorhandler": "^1.5.1",
+    "evernote": "^2.0.5",
+    "express": "^4.17.1",
+    "express-session": "^1.17.0",
+    "hogan-express": "^0.5.2",
+    "method-override": "^3.0.0",
+    "morgan": "^1.9.1",
+    "node-compass": "^0.2.4",
+    "serve-favicon": "^2.5.0"
   }
 }


### PR DESCRIPTION
This updates the code to run with current (2020-02-03) libraries.

- Uses evernote 2.0.5. This moved some classes around and uses Promises instead of callbacks. Error handling is still perfunctory.
- Use Express 4.17.1. Most middleware was moved to independent projects (see [this](https://github.com/senchalabs/connect#middleware)) so the app gets set up slightly differently.
- Now passes npm audit!

With these changes I was able to get the project running against the evernote sandbox server.

This code is pretty rough, so I'll understand if you don't want to merge it. However, I thought making a PR would at least make the fixes more searchable if someone else wants to do a cleanup.